### PR TITLE
Article meta display

### DIFF
--- a/frontend/extension/content.js
+++ b/frontend/extension/content.js
@@ -15,10 +15,13 @@ function selectQualifiedContentFromDOM(selectors, qualifiedName) {
 
 function getPageText() {
     let dateSearch = selectQualifiedContentFromDOM('meta[property*="time"]', "content");
-    const date = dateSearch == null ? "" : new Date(dateSearch).toLocaleDateString();
+    const date = (dateSearch == null ? new Date() : new Date(dateSearch)).toLocaleDateString();
+
+    let siteSearch = selectQualifiedContentFromDOM('meta[name*="site"]', "content");
+    const site = siteSearch ?? "@news";
 
     let authorSearch = selectQualifiedContentFromDOM('meta[name*="author"]', "content");
-    const author = authorSearch ?? "";
+    const author = authorSearch ?? site;
 
     let titleSearch = selectQualifiedContentFromDOM('meta[name*="title"], meta[property*="title"]', "content");
     const title = titleSearch ?? document.title;

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -1,115 +1,115 @@
-@import "components/ArticleSection/article.scss";
-@import "components/Lens/lens.scss";
-@import "components/Loader/loader.scss";
-@import "components/Sidebar/sidebar.scss";
+@import 'components/ArticleSection/article.scss';
+@import 'components/Lens/lens.scss';
+@import 'components/Loader/loader.scss';
+@import 'components/Sidebar/sidebar.scss';
 
 html {
-    font-family: 'Sora', sans-serif;
-    background-color: var(--extension-primary);
-    margin: 0;
-    padding: 0;
+  font-family: 'Sora', sans-serif;
+  background-color: var(--extension-primary);
+  margin: 0;
+  padding: 0;
 }
 
 body {
-    background-color: transparent;
-    pointer-events: none;
-    margin: 0;
+  background-color: transparent;
+  pointer-events: none;
+  margin: 0;
 }
 
 * {
-    pointer-events: all;
+  pointer-events: all;
 }
 
 *::-webkit-scrollbar {
-    width: 0;               /* width of the entire scrollbar */
+  width: 0; /* width of the entire scrollbar */
 }
 
 #launchpad-essentially {
-    --extension-tertiary: #191b43;
-    --extension-secondary: #191b43;
-    --extension-primary: #e9e9e9;
+  --extension-tertiary: #191b43;
+  --extension-secondary: #191b43;
+  --extension-primary: #e9e9e9;
 
-    button {
-        color: white;
-    }
+  button {
+    color: white;
+  }
 
-    h1 {
-        font-size: 0.8rem;
-        padding: 0;
-        margin: 0;
-    }
+  h1 {
+    font-size: 0.8rem;
+    padding: 0;
+    margin: 0;
+  }
 
-    h2 {
-        font-size: 0.7rem;
-        padding: 0;
-        margin: 0;
-    }
+  h2 {
+    font-size: 0.7rem;
+    padding: 0;
+    margin: 0;
+  }
 
-    h6 {
-        font-size: 0.4rem;
-        padding: 0;
-        margin: 0;
-    }
+  h6 {
+    font-size: 0.4rem;
+    padding: 0;
+    margin: 0;
+  }
 
-    .start {
-        padding: 5px 0 15px;
-        width: 200px;
-    }
+  .start {
+    padding: 5px 0 15px;
+    width: 200px;
+  }
 
-    .actions button {
-        padding: 8px 12px;
-        margin: 5px;
-        border-radius: 7px;
-        background-color: var(--extension-secondary);
-        outline: none;
-        font-size: 10px;
-        border: none;
-    }
+  .actions button {
+    padding: 8px 12px;
+    margin: 5px;
+    border-radius: 7px;
+    background-color: var(--extension-secondary);
+    outline: none;
+    font-size: 10px;
+    border: none;
+  }
 
-    .actions {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
-    }
+  .actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  }
 
-    .popup {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-end;
-        align-items: flex-start;
-        max-height: 900px;
-    }
+  .popup {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: flex-start;
+    max-height: 900px;
+  }
 
-    .settings {
-        margin: 4px 7px;
-    }
+  .settings {
+    margin: 4px 7px;
+  }
 
-    .dropdown {
-        display: flex;
-        flex-direction: column;
-    }
+  .dropdown {
+    display: flex;
+    flex-direction: column;
+  }
 
-    .dropdown button {
-        padding: 4px 10px;
-        margin: 0;
-        border-radius: 3px;
-        background-color: var(--extension-primary);
-        outline: none;
-        font-size: 10px;
-        border: none;
-    }
+  .dropdown button {
+    padding: 4px 10px;
+    margin: 0;
+    border-radius: 3px;
+    background-color: var(--extension-primary);
+    outline: none;
+    font-size: 10px;
+    border: none;
+  }
 
-    .dropdown>div {
-        margin: 5px 0;
-        display: flex;
-        flex-direction: column;
-        background-color: var(--extension-primary);
-        border-radius: 3px;
-    }
+  .dropdown > div {
+    margin: 5px 0;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--extension-primary);
+    border-radius: 3px;
+  }
 
-    .page {
-        display: flex;
-        flex-direction: row;
-    }
+  .page {
+    display: flex;
+    flex-direction: row;
+  }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,13 +6,13 @@ import Article, { IArticleData } from './components/ArticleSection/index';
 function App() {
   const ESSENTIALLY = 'Essentially';
   const EMPTY_TEXT = {
-    title: "",
-    date: "",
-    author: "",
-    website: "",
-    icon: "",
-    body: []
-  }
+    title: '',
+    date: '',
+    author: '',
+    website: '',
+    icon: '',
+    body: [],
+  };
 
   const [text, setText] = useState<IArticleData>(EMPTY_TEXT);
   const [showSettings, setShowSettings] = useState(false);
@@ -22,32 +22,32 @@ function App() {
     try {
       let text = '';
       Array.from(document.body.getElementsByTagName('p')).forEach(
-          (element) => (text += element.innerText)
+        (element) => (text += element.innerText)
       );
 
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         if (tabs[0].id) {
           chrome.tabs.sendMessage(
-              tabs[0].id,
-              { greeting: 'hello' },
-              function (response) {
-                setText(response.text);
-              }
+            tabs[0].id,
+            { greeting: 'hello' },
+            function (response) {
+              setText(response.text);
+            }
           );
         }
       });
     } catch (exception) {
       console.log('COULD NOT CONNECT TO CHROME');
       setText({
-            title: "DEFAULT TITLE",
-            date: "DEFAULT DATE",
-            author: "DEFAULT AUTHOR",
-            website: "DEFAULT WEBSITE",
-            icon: "DEFAULT ICON",
-            body: [
+        title: 'DEFAULT TITLE',
+        date: 'DEFAULT DATE',
+        author: 'DEFAULT AUTHOR',
+        website: 'DEFAULT WEBSITE',
+        icon: 'DEFAULT ICON',
+        body: [
           'Setting zero for offset and blur When the x-offset, y-offset, and blur are all zero, the box shadow will be a solid-colored outline of equal-size on all sides. The shadows are drawn back to front, so the first shadow sits on top of subsequent shadows. When the border-radius is set to 0, as is the default, the corners of the shadow will be, well, corners.',
           " Had we put    i i   \t     in a border-radius of any other value, the corners would have been rounded.We added a margin the size of the widest box-shadow to ensure the shadow doesn't overlap adjacent elements or go beyond the border of the containing box. A box-shadow does not impact box model dimensions.Setting zero for offset and blur When the x-offset, y-offset, and blur are all zero, the box shadow will be a solid-colored outline of equal-size on all sides. The shadows are drawn back to front, so the first shadow sits on top of subsequent shadows.",
-        ]
+        ],
       });
     }
   };
@@ -59,63 +59,65 @@ function App() {
   const settingsMenu = () => {
     if (showSettings) {
       return (
-          <div className="settings">
-            <div className="dropdown">
-              <button>Settings</button>
-              <div>
-                <button>Summary Length</button>
-                <button>Appearance</button>
-              </div>
+        <div className="settings">
+          <div className="dropdown">
+            <button>Settings</button>
+            <div>
+              <button>Summary Length</button>
+              <button>Appearance</button>
             </div>
           </div>
+        </div>
       );
     }
     return <></>;
   };
 
   if (text.body.length > 0) {
-    return <Article
+    return (
+      <Article
         title={text.title}
         date={text.date}
         author={text.author}
         website={text.website}
         body={text.body}
         close={close}
-    />;
+      />
+    );
   }
 
   return (
-      <div className="popup">
-        <div className="main">
-          <div className="start">
-            <nav>
-              <h1>{ESSENTIALLY}</h1>
-              <button onClick={() => setShowSettings((prev) => !prev)}>
-                <svg
-                    width="22"
-                    height="22"
-                    viewBox="0 0 22 22"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                      d="M12.6688 20.1668H9.33209C9.12303 20.1669 8.92023 20.0954 8.75734 19.9644C8.59445 19.8333 8.48125 19.6505 8.43651 19.4463L8.06342 17.7193C7.56573 17.5013 7.0938 17.2286 6.65634 16.9062L4.97242 17.4425C4.77311 17.5061 4.55804 17.4995 4.36295 17.424C4.16786 17.3485 4.00447 17.2085 3.89992 17.0272L2.22792 14.1388C2.12447 13.9575 2.08564 13.7463 2.11778 13.54C2.14992 13.3337 2.25112 13.1444 2.40484 13.0031L3.71109 11.8114C3.65169 11.2716 3.65169 10.7269 3.71109 10.1871L2.40484 8.99816C2.25091 8.85679 2.14956 8.66731 2.11742 8.4608C2.08527 8.25428 2.12424 8.04297 2.22792 7.8615L3.89626 4.97125C4.0008 4.79004 4.16419 4.65004 4.35928 4.5745C4.55438 4.49897 4.76944 4.49243 4.96876 4.556L6.65267 5.09225C6.87634 4.92725 7.10917 4.77325 7.34934 4.63391C7.58126 4.50375 7.81959 4.3855 8.06342 4.28008L8.43742 2.55491C8.48195 2.35068 8.59494 2.16779 8.75766 2.03658C8.92038 1.90537 9.12306 1.83372 9.33209 1.8335H12.6688C12.8778 1.83372 13.0805 1.90537 13.2432 2.03658C13.4059 2.16779 13.5189 2.35068 13.5634 2.55491L13.9411 4.281C14.4381 4.50032 14.9099 4.77295 15.3482 5.09408L17.033 4.55783C17.2322 4.4945 17.4471 4.50115 17.642 4.57668C17.8368 4.6522 18.0001 4.79206 18.1046 4.97308L19.7729 7.86333C19.9856 8.23641 19.9123 8.7085 19.596 8.99908L18.2898 10.1907C18.3492 10.7306 18.3492 11.2753 18.2898 11.8151L19.596 13.0067C19.9123 13.2982 19.9856 13.7694 19.7729 14.1425L18.1046 17.0327C18 17.214 17.8367 17.354 17.6416 17.4295C17.4465 17.505 17.2314 17.5116 17.0321 17.448L15.3482 16.9117C14.911 17.2338 14.4394 17.5062 13.942 17.7239L13.5634 19.4463C13.5187 19.6504 13.4056 19.8331 13.2429 19.9641C13.0802 20.0951 12.8777 20.1667 12.6688 20.1668V20.1668ZM10.9968 7.3335C10.0243 7.3335 9.09166 7.7198 8.40403 8.40744C7.7164 9.09507 7.33009 10.0277 7.33009 11.0002C7.33009 11.9726 7.7164 12.9053 8.40403 13.5929C9.09166 14.2805 10.0243 14.6668 10.9968 14.6668C11.9692 14.6668 12.9018 14.2805 13.5895 13.5929C14.2771 12.9053 14.6634 11.9726 14.6634 11.0002C14.6634 10.0277 14.2771 9.09507 13.5895 8.40744C12.9018 7.7198 11.9692 7.3335 10.9968 7.3335V7.3335Z"
-                      fill="#D9D9D9"
-                  />
-                </svg>
-              </button>
-            </nav>
+    <div className="popup">
+      <div className="main">
+        <div className="start">
+          <nav>
+            <h1>{ESSENTIALLY}</h1>
+            <button onClick={() => setShowSettings((prev) => !prev)}>
+              <svg
+                width="22"
+                height="22"
+                viewBox="0 0 22 22"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12.6688 20.1668H9.33209C9.12303 20.1669 8.92023 20.0954 8.75734 19.9644C8.59445 19.8333 8.48125 19.6505 8.43651 19.4463L8.06342 17.7193C7.56573 17.5013 7.0938 17.2286 6.65634 16.9062L4.97242 17.4425C4.77311 17.5061 4.55804 17.4995 4.36295 17.424C4.16786 17.3485 4.00447 17.2085 3.89992 17.0272L2.22792 14.1388C2.12447 13.9575 2.08564 13.7463 2.11778 13.54C2.14992 13.3337 2.25112 13.1444 2.40484 13.0031L3.71109 11.8114C3.65169 11.2716 3.65169 10.7269 3.71109 10.1871L2.40484 8.99816C2.25091 8.85679 2.14956 8.66731 2.11742 8.4608C2.08527 8.25428 2.12424 8.04297 2.22792 7.8615L3.89626 4.97125C4.0008 4.79004 4.16419 4.65004 4.35928 4.5745C4.55438 4.49897 4.76944 4.49243 4.96876 4.556L6.65267 5.09225C6.87634 4.92725 7.10917 4.77325 7.34934 4.63391C7.58126 4.50375 7.81959 4.3855 8.06342 4.28008L8.43742 2.55491C8.48195 2.35068 8.59494 2.16779 8.75766 2.03658C8.92038 1.90537 9.12306 1.83372 9.33209 1.8335H12.6688C12.8778 1.83372 13.0805 1.90537 13.2432 2.03658C13.4059 2.16779 13.5189 2.35068 13.5634 2.55491L13.9411 4.281C14.4381 4.50032 14.9099 4.77295 15.3482 5.09408L17.033 4.55783C17.2322 4.4945 17.4471 4.50115 17.642 4.57668C17.8368 4.6522 18.0001 4.79206 18.1046 4.97308L19.7729 7.86333C19.9856 8.23641 19.9123 8.7085 19.596 8.99908L18.2898 10.1907C18.3492 10.7306 18.3492 11.2753 18.2898 11.8151L19.596 13.0067C19.9123 13.2982 19.9856 13.7694 19.7729 14.1425L18.1046 17.0327C18 17.214 17.8367 17.354 17.6416 17.4295C17.4465 17.505 17.2314 17.5116 17.0321 17.448L15.3482 16.9117C14.911 17.2338 14.4394 17.5062 13.942 17.7239L13.5634 19.4463C13.5187 19.6504 13.4056 19.8331 13.2429 19.9641C13.0802 20.0951 12.8777 20.1667 12.6688 20.1668V20.1668ZM10.9968 7.3335C10.0243 7.3335 9.09166 7.7198 8.40403 8.40744C7.7164 9.09507 7.33009 10.0277 7.33009 11.0002C7.33009 11.9726 7.7164 12.9053 8.40403 13.5929C9.09166 14.2805 10.0243 14.6668 10.9968 14.6668C11.9692 14.6668 12.9018 14.2805 13.5895 13.5929C14.2771 12.9053 14.6634 11.9726 14.6634 11.0002C14.6634 10.0277 14.2771 9.09507 13.5895 8.40744C12.9018 7.7198 11.9692 7.3335 10.9968 7.3335V7.3335Z"
+                  fill="#D9D9D9"
+                />
+              </svg>
+            </button>
+          </nav>
 
-            <ArticleSection text={text.body} />
-            <section className="actions">
-              {!text.body.length && (
-                  <button onClick={() => callExtension()}>SUMMARIZE</button>
-              )}
-            </section>
-          </div>
+          <ArticleSection text={text.body} />
+          <section className="actions">
+            {!text.body.length && (
+              <button onClick={() => callExtension()}>SUMMARIZE</button>
+            )}
+          </section>
         </div>
-        {settingsMenu()}
       </div>
+      {settingsMenu()}
+    </div>
   );
 }
 

--- a/frontend/src/components/ArticleSection/article.scss
+++ b/frontend/src/components/ArticleSection/article.scss
@@ -144,20 +144,37 @@
     margin: 0;
   }
 
-  .keywords {
+  .article-meta {
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
+  }
+
+  .article-meta p {
+    font-weight: bold;
+    padding: 2px;
+    margin: 0 5px 0 0;
+    border-radius: 5px;
+  }
+
+  .keywords {
+    display: flex;
+    flex-grow: 3;
     padding: 6px 0;
+    width: auto;
   }
 
   .keywords p {
     border: 1px solid var(--extension-tertiary);
-    font-weight: bold;
     font-size: 9px;
-    padding: 2px;
-    margin: 0 5px 0 0;
-    border-radius: 5px;
+  }
+
+  .extracted-article-meta {
+    margin: auto 0 auto auto;
+  }
+
+  .extracted-article-meta p {
+    font-size: 10px;
   }
 
   .popup .main {

--- a/frontend/src/components/ArticleSection/article.scss
+++ b/frontend/src/components/ArticleSection/article.scss
@@ -1,171 +1,171 @@
 #launchpad-essentially {
-    nav {
-        margin: 0 5px 10px;
-        padding: 5px;
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-    }
+  nav {
+    margin: 0 5px 10px;
+    padding: 5px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
 
-    nav button {
-        border-radius: 100%;
-        background: none;
-        outline: none;
-        border: none;
-    }
+  nav button {
+    border-radius: 100%;
+    background: none;
+    outline: none;
+    border: none;
+  }
 
-    .article {
-        overflow: hidden;
-        max-width: 500px;
-        border-radius: 6px;
-        margin: 10px;
-        font-size: 11px;
-        background-color: #ffffff;
-        z-index: 20;
-        max-height: 300px;
-        box-shadow: 0 2px 3px 1px rgba(0, 0, 0, 0.15);
-        padding: 10px 10px 5px;
-    }
+  .article {
+    overflow: hidden;
+    max-width: 500px;
+    border-radius: 6px;
+    margin: 10px;
+    font-size: 11px;
+    background-color: #ffffff;
+    z-index: 20;
+    max-height: 300px;
+    box-shadow: 0 2px 3px 1px rgba(0, 0, 0, 0.15);
+    padding: 10px 10px 5px;
+  }
 
-    .article .a {
-        padding: 0 25px 2px;
-        text-align: justify;
-        overflow-y: scroll;
-        width: fit-content;
-        min-width: 300px;
-        max-height: 45vh;
-    }
+  .article .a {
+    padding: 0 25px 2px;
+    text-align: justify;
+    overflow-y: scroll;
+    width: fit-content;
+    min-width: 300px;
+    max-height: 45vh;
+  }
 
-    .article p {
-        padding-top: 3px;
-    }
+  .article p {
+    padding-top: 3px;
+  }
 
-    .article .bottom-bar {
-        background-color: var(--extension-tertiary);
-        width: 100%;
-        height: 35px;
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
-    }
+  .article .bottom-bar {
+    background-color: var(--extension-tertiary);
+    width: 100%;
+    height: 35px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  }
 
-    .article .top-bar {
-        width: 100%;
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-    }
+  .article .top-bar {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
 
-    .article .top-bar div {
-        width: fit-content;
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-    }
+  .article .top-bar div {
+    width: fit-content;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
 
-    .article .top-bar h2 {
-        margin: 0 10px;
-    }
+  .article .top-bar h2 {
+    margin: 0 10px;
+  }
 
-    .article .top-bar button {
-        background: none;
-        outline: none;
-        border: none;
-    }
+  .article .top-bar button {
+    background: none;
+    outline: none;
+    border: none;
+  }
 
-    .article .bottom-bar>button {
-        background-color: var(--extension-secondary);
-        font-weight: 500;
-        width: 30px;
-        height: 30px;
-        font-size: 13px;
-        padding: 3px 3px;
-        margin: 2px;
-        border: none;
-        outline: none;
-        border-radius: 100%;
-        position: relative;
-    }
+  .article .bottom-bar > button {
+    background-color: var(--extension-secondary);
+    font-weight: 500;
+    width: 30px;
+    height: 30px;
+    font-size: 13px;
+    padding: 3px 3px;
+    margin: 2px;
+    border: none;
+    outline: none;
+    border-radius: 100%;
+    position: relative;
+  }
 
-    .article .bottom-bar>button * {
-        width: 100%;
-        height: 100%;
-        background-color: transparent !important;
-        position: absolute;
-        top: 0;
-        left: 0;
-    }
+  .article .bottom-bar > button * {
+    width: 100%;
+    height: 100%;
+    background-color: transparent !important;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
 
-    .article ::-moz-selection {
-        /* Code for Firefox */
-        color: var(--extension-primary);
-        background: var(--extension-secondary);
-    }
+  .article ::-moz-selection {
+    /* Code for Firefox */
+    color: var(--extension-primary);
+    background: var(--extension-secondary);
+  }
 
-    .article ::selection {
-        color: var(--extension-primary);
-        background: var(--extension-secondary);
-    }
+  .article ::selection {
+    color: var(--extension-primary);
+    background: var(--extension-secondary);
+  }
 
-    .article-body {
-        padding: 4px 5px 5px 20px;
-        display: flex;
-        flex-direction:column;
-    }
+  .article-body {
+    padding: 4px 5px 5px 20px;
+    display: flex;
+    flex-direction: column;
+  }
 
-    .article-body h1 {
-        font-size: 14px;
-        font-weight: bold;
-    }
+  .article-body h1 {
+    font-size: 14px;
+    font-weight: bold;
+  }
 
-    .article-body h6 {
-        font-size: 11px;
-        font-style: italic;
-        font-weight: 300;
-        padding: 3px 0;
-    }
+  .article-body h6 {
+    font-size: 11px;
+    font-style: italic;
+    font-weight: 300;
+    padding: 3px 0;
+  }
 
-    .article-body nav {
-        width: 100%;
-        display: flex;
-        flex-direction: row-reverse;
-        padding: 0;
-        margin: 0;
-    }
+  .article-body nav {
+    width: 100%;
+    display: flex;
+    flex-direction: row-reverse;
+    padding: 0;
+    margin: 0;
+  }
 
-    .article-body nav button {
-        background: none;
-        width: 25px;
-        height: 25px;
-        margin: 0;
-    }
+  .article-body nav button {
+    background: none;
+    width: 25px;
+    height: 25px;
+    margin: 0;
+  }
 
-    .keywords {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-start;
-        padding: 6px 0;
-    }
+  .keywords {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    padding: 6px 0;
+  }
 
-    .keywords p {
-        border: 1px solid var(--extension-tertiary);
-        font-weight: bold;
-        font-size: 9px;
-        padding: 2px;
-        margin: 0 5px 0 0;
-        border-radius: 5px;
-    }
+  .keywords p {
+    border: 1px solid var(--extension-tertiary);
+    font-weight: bold;
+    font-size: 9px;
+    padding: 2px;
+    margin: 0 5px 0 0;
+    border-radius: 5px;
+  }
 
-    .popup .main {
-        position: sticky;
-        top: 0;
-        right: 0;
-        border-radius: 6px;
-        background-color: var(--extension-primary);
-        box-shadow: 0 2px 7px 1px rgba(0, 0, 0, 0.25);
-    }
+  .popup .main {
+    position: sticky;
+    top: 0;
+    right: 0;
+    border-radius: 6px;
+    background-color: var(--extension-primary);
+    box-shadow: 0 2px 7px 1px rgba(0, 0, 0, 0.25);
+  }
 }

--- a/frontend/src/components/ArticleSection/index.tsx
+++ b/frontend/src/components/ArticleSection/index.tsx
@@ -123,12 +123,18 @@ export default function Article(props: ArticleProps) {
           <h6>{readTime}</h6>
           <div>
             <h1>{pageTitle}</h1>
-            <h6>{props.date}</h6>
           </div>
-          <div className="keywords">
-            {keywords.map((keyword) => (
-              <p key={keyword}>{keyword.toUpperCase()}</p>
-            ))}
+          <div className="article-meta">
+            <div className="keywords">
+              {keywords.map((keyword) => (
+                <p key={keyword}>{keyword.toUpperCase()}</p>
+              ))}
+            </div>
+            <div className="extracted-article-meta">
+              <p>
+                {props.author} | {props.date}
+              </p>
+            </div>
           </div>
           <Lens>
             <ArticleSection text={summary} />

--- a/frontend/src/components/Lens/index.tsx
+++ b/frontend/src/components/Lens/index.tsx
@@ -1,108 +1,130 @@
-import {useState, useRef, useEffect} from 'react';
-import LensHelper from "./lensHelper";
+import { useState, useRef, useEffect } from 'react';
+import LensHelper from './lensHelper';
 
-type TextActions = "None" | "Google" | "Lens" | "Format" | "Define";
+type TextActions = 'None' | 'Google' | 'Lens' | 'Format' | 'Define';
 
-export default function Lens({children}: { children: JSX.Element }) {
-    const DEFINITION_POPUP_ID = 'definition-popup';
-    const [selectionText, setSelectionText] = useState<string | null>(null);
-    const [runLens, setRunLens] = useState<boolean>(false);
-    const [options, setOptions] = useState<TextActions>("None");
-    const ref = useRef<HTMLElement>(null);
+export default function Lens({ children }: { children: JSX.Element }) {
+  const DEFINITION_POPUP_ID = 'definition-popup';
+  const [selectionText, setSelectionText] = useState<string | null>(null);
+  const [runLens, setRunLens] = useState<boolean>(false);
+  const [options, setOptions] = useState<TextActions>('None');
+  const ref = useRef<HTMLElement>(null);
 
-    useEffect(() => {
-        if (options === "Google" && selectionText) {
-            window.open(`https://www.google.com/search?q=${selectionText?.replace(" ", "+")}`, '_blank');
+  useEffect(() => {
+    if (options === 'Google' && selectionText) {
+      window.open(
+        `https://www.google.com/search?q=${selectionText?.replace(' ', '+')}`,
+        '_blank'
+      );
+    }
+    if (options === 'Lens') {
+      setRunLens(true);
+    } else {
+      setRunLens(false);
+    }
+  }, [options]);
+
+  useEffect(() => {
+    if (!selectionText) {
+      setOptions('None');
+    }
+  }, [selectionText]);
+
+  document.addEventListener('selectionchange', () => {
+    const selection = document.getSelection();
+    if (selection == null || selection.toString().length == 0) {
+      setSelectionText(null);
+      return;
+    }
+    try {
+      if (
+        selection.focusNode != null &&
+        selection.focusNode.parentElement != null &&
+        selection.focusNode.parentElement.closest(`#${DEFINITION_POPUP_ID}`) !=
+          null
+      ) {
+        const element = selection.focusNode.parentElement.closest(
+          `#${DEFINITION_POPUP_ID}`
+        );
+        if (!element || element.id !== `${DEFINITION_POPUP_ID}`) {
+          return;
         }
-        if (options === "Lens") {
-            setRunLens(true)
-        } else {
-            setRunLens(false)
-        }
-    }, [options])
+      } else {
+        return;
+      }
+    } catch (e) {
+      return;
+    }
 
-    useEffect(() => {
-        if (!selectionText) {
-            setOptions("None")
-        }
-    }, [selectionText])
+    setSelectionText(selection.toString());
+    const range = selection.getRangeAt(0).cloneRange();
+    if (!range.getClientRects) return null;
+    range.collapse(true);
+    const rects = range.getClientRects();
+    if (rects.length <= 0) return null;
+    const rect = rects[0];
+    if (ref.current) {
+      ref.current.style.position = 'absolute';
+      ref.current.style.left = 0 + 'px';
+      ref.current.style.top =
+        rect.top - 20 - ref.current.offsetHeight < 0
+          ? 0 + 'px'
+          : rect.top - 20 - ref.current.offsetHeight + 'px';
+    }
+  });
 
-    document.addEventListener('selectionchange', () => {
-        const selection = document.getSelection();
-        if (selection == null || selection.toString().length == 0) {
-            setSelectionText(null);
-            return;
-        }
-        try {
-            if (
-                selection.focusNode != null &&
-                selection.focusNode.parentElement != null &&
-                selection.focusNode.parentElement.closest(`#${DEFINITION_POPUP_ID}`) !=
-                null
-            ) {
-                const element = selection.focusNode.parentElement.closest(
-                    `#${DEFINITION_POPUP_ID}`
-                );
-                if (!element || element.id !== `${DEFINITION_POPUP_ID}`) {
-                    return;
-                }
-            } else {
-                return;
-            }
-        } catch (e) {
-            return;
-        }
-
-        setSelectionText(selection.toString());
-        const range = selection.getRangeAt(0).cloneRange();
-        if (!range.getClientRects) return null;
-        range.collapse(true);
-        const rects = range.getClientRects();
-        if (rects.length <= 0) return null;
-        const rect = rects[0];
-        if (ref.current) {
-            ref.current.style.position = 'absolute';
-            ref.current.style.left = 0 + 'px';
-            ref.current.style.top =
-                rect.top - 20 - ref.current.offsetHeight < 0
-                    ? 0 + 'px'
-                    : rect.top - 20 - ref.current.offsetHeight + 'px';
-        }
-    });
-
-    return (
-        <div id={DEFINITION_POPUP_ID}>
-            {children}
-            {selectionText && (
-                <section ref={ref} id={`${DEFINITION_POPUP_ID}-hov`}>
-                    <button className={options === "Google" ? "selected" : ""} onClick={() => {
-                        setOptions("Google")
-                    }}>Google
-                    </button>
-                    <button className={"not-ready"} onClick={() => {
-                        setOptions("Format")
-                    }}>Format
-                    </button>
-                    <button className={options === "Lens" ? "selected" : ""} onClick={() => {
-                        setOptions("Lens")
-                    }}>Lens
-                    </button>
-                </section>
-            )}
-            {runLens && selectionText && (
-                <div className={"lens-result"}>
-                    <svg className={"connect"} width="284" height="175" viewBox="0 0 284 175" fill="none"
-                         xmlns="http://www.w3.org/2000/svg">
-                        <path
-                            d="M22.0009 11.4998C-2.49913 13.9998 18.001 23.4998 43.0009 32.9998C68.0008 42.4998 57.5011 57.4998 22.0009 59.9998C-13.4993 62.4998 7.00107 84.9998 39.5009 82.4998C72.0007 79.9998 60.0008 94.4998 24.0009 110.5C-11.9991 126.5 -6.49918 120.5 43.0009 130C92.5009 139.5 -40.5 138.5 22.0009 161.5C84.5017 184.5 247.5 172 271.001 161.5C294.502 151 281.002 138 243.001 139.5C205 141 267 134 264.501 121.5C262.002 109 243.002 102 221.001 90.4998C199 78.9998 244.001 76.4998 257.501 59.9998C271.001 43.4998 235.502 47.9998 230.501 35.9998C225.5 23.9998 271.001 14.9998 257.501 4.49976C244.001 -6.00024 46.5009 8.99976 22.0009 11.4998Z"
-                            fill="#191B43" stroke="black"/>
-                    </svg>
-                    <section className={'reference'}>
-                        <LensHelper textSelection={selectionText}/>
-                    </section>
-                </div>
-            )}
-
+  return (
+    <div id={DEFINITION_POPUP_ID}>
+      {children}
+      {selectionText && (
+        <section ref={ref} id={`${DEFINITION_POPUP_ID}-hov`}>
+          <button
+            className={options === 'Google' ? 'selected' : ''}
+            onClick={() => {
+              setOptions('Google');
+            }}
+          >
+            Google
+          </button>
+          <button
+            className={'not-ready'}
+            onClick={() => {
+              setOptions('Format');
+            }}
+          >
+            Format
+          </button>
+          <button
+            className={options === 'Lens' ? 'selected' : ''}
+            onClick={() => {
+              setOptions('Lens');
+            }}
+          >
+            Lens
+          </button>
+        </section>
+      )}
+      {runLens && selectionText && (
+        <div className={'lens-result'}>
+          <svg
+            className={'connect'}
+            width="284"
+            height="175"
+            viewBox="0 0 284 175"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M22.0009 11.4998C-2.49913 13.9998 18.001 23.4998 43.0009 32.9998C68.0008 42.4998 57.5011 57.4998 22.0009 59.9998C-13.4993 62.4998 7.00107 84.9998 39.5009 82.4998C72.0007 79.9998 60.0008 94.4998 24.0009 110.5C-11.9991 126.5 -6.49918 120.5 43.0009 130C92.5009 139.5 -40.5 138.5 22.0009 161.5C84.5017 184.5 247.5 172 271.001 161.5C294.502 151 281.002 138 243.001 139.5C205 141 267 134 264.501 121.5C262.002 109 243.002 102 221.001 90.4998C199 78.9998 244.001 76.4998 257.501 59.9998C271.001 43.4998 235.502 47.9998 230.501 35.9998C225.5 23.9998 271.001 14.9998 257.501 4.49976C244.001 -6.00024 46.5009 8.99976 22.0009 11.4998Z"
+              fill="#191B43"
+              stroke="black"
+            />
+          </svg>
+          <section className={'reference'}>
+            <LensHelper textSelection={selectionText} />
+          </section>
         </div>
-    );
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/Lens/lens.scss
+++ b/frontend/src/components/Lens/lens.scss
@@ -1,158 +1,157 @@
 #launchpad-essentially {
-    #definition-popup-hov {
-        background-color: #ffffff;
-        box-shadow: 0 2px 5px 1px rgba(0, 0, 0, 0.15);
-        border-radius: 3px;
-        max-height: 140px;
-        max-width: 380px;
-        margin: 10px;
-        user-select: none;
-        overflow: hidden;
-        font-size: 12px;
-        display: flex;
-        flex-direction: row;
-    }
+  #definition-popup-hov {
+    background-color: #ffffff;
+    box-shadow: 0 2px 5px 1px rgba(0, 0, 0, 0.15);
+    border-radius: 3px;
+    max-height: 140px;
+    max-width: 380px;
+    margin: 10px;
+    user-select: none;
+    overflow: hidden;
+    font-size: 12px;
+    display: flex;
+    flex-direction: row;
+  }
 
-    #definition-popup-hov h6 {
-        font-weight: bold;
-        font-size: 15px;
-    }
+  #definition-popup-hov h6 {
+    font-weight: bold;
+    font-size: 15px;
+  }
 
-    #definition-popup {
-        max-width: 450px;
-    }
+  #definition-popup {
+    max-width: 450px;
+  }
 
-    #definition-popup-hov button {
-        outline: none;
-        color: #191b43;
-        background: transparent;
-        border: none;
-        font-weight: bold;
-        padding: 5px 8px;
-        font-size: 11px;
-    }
+  #definition-popup-hov button {
+    outline: none;
+    color: #191b43;
+    background: transparent;
+    border: none;
+    font-weight: bold;
+    padding: 5px 8px;
+    font-size: 11px;
+  }
 
-    #definition-popup-hov .selected {
-        outline: none;
-        color: #ffffff;
-        background: #191b43;
-        border: none;
-        padding: 2px 8px;
-    }
+  #definition-popup-hov .selected {
+    outline: none;
+    color: #ffffff;
+    background: #191b43;
+    border: none;
+    padding: 2px 8px;
+  }
 
-    #definition-popup-hov .not-ready {
-        color: gray;
-    }
+  #definition-popup-hov .not-ready {
+    color: gray;
+  }
 
-    #definition-popup-hov p {
-        padding: 5px;
-    }
+  #definition-popup-hov p {
+    padding: 5px;
+  }
 
-    .reference {
-        border-radius: 8px;
-        background-color: #ffffff;
-        margin: 10px;
-    }
+  .reference {
+    border-radius: 8px;
+    background-color: #ffffff;
+    margin: 10px;
+  }
 
-    @keyframes flowAnimation {
-        0% {
-            top: -100px;
-        }
-        50% {
-            top: -20px;
-        }
-        100% {
-            top: -100px;
-        }
+  @keyframes flowAnimation {
+    0% {
+      top: -100px;
     }
+    50% {
+      top: -20px;
+    }
+    100% {
+      top: -100px;
+    }
+  }
 
-    .connect {
-        left: 50%;
-        position: absolute;
-        top: -5px;
-        transform: translateX( -50%);
-        z-index: -2;
-        animation: 10s linear 0s infinite flowAnimation;
-        animation-timing-function: linear;
-    }
+  .connect {
+    left: 50%;
+    position: absolute;
+    top: -5px;
+    transform: translateX(-50%);
+    z-index: -2;
+    animation: 10s linear 0s infinite flowAnimation;
+    animation-timing-function: linear;
+  }
 
-    .lens-result {
-        position: relative;
-    }
+  .lens-result {
+    position: relative;
+  }
 
-    .lens-panel {
-        display: flex;
-        flex-direction: column;
-        padding: 5px 0 0 0;
-        justify-content: space-between;
-        height: 180px;
-        user-select: none;
-        border: 2px solid var(--extension-secondary);
-        border-radius: 8px;
-    }
+  .lens-panel {
+    display: flex;
+    flex-direction: column;
+    padding: 5px 0 0 0;
+    justify-content: space-between;
+    height: 180px;
+    user-select: none;
+    border: 2px solid var(--extension-secondary);
+    border-radius: 8px;
+  }
 
-    .lens-panel-content {
-        padding: 2px 10px;
-        width: inherit;
-        display: flex;
-        flex-direction: column;
-        flex-wrap: wrap;
-        overflow-y: scroll;
+  .lens-panel-content {
+    padding: 2px 10px;
+    width: inherit;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    overflow-y: scroll;
+  }
+  .choices {
+    width: 100%;
+    padding: 2px 0;
+    background-color: #191b43;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+  }
 
-    }
-    .choices {
-        width: 100%;
-        padding: 2px 0;
-        background-color: #191b43;
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-    }
+  .choices button {
+    background: transparent;
+    color: var(--extension-primary);
+    border: 1px solid transparent;
+    font-weight: bold;
+    font-size: 10px;
+    padding: 2px 3px;
+    margin: 1px 5px;
+  }
 
-    .choices button {
-        background: transparent;
-        color: var(--extension-primary);
-        border: 1px solid transparent;
-        font-weight: bold;
-        font-size: 10px;
-        padding: 2px 3px;
-        margin: 1px 5px;
-    }
+  .choices .selected-panel {
+    border: 1px solid var(--extension-primary);
+    border-radius: 4px;
+  }
 
-    .choices .selected-panel {
-        border: 1px solid var(--extension-primary);
-        border-radius: 4px;
-    }
+  .reference-panel {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    width: inherit;
+    flex-wrap: wrap;
+  }
 
-    .reference-panel {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-evenly;
-        width: inherit;
-        flex-wrap: wrap;
-    }
+  .reference-panel div {
+    margin: 10px 0;
+  }
 
-    .reference-panel div {
-        margin: 10px 0;
-    }
+  .reference-panel h2 {
+    font-size: 12px;
+  }
 
-    .reference-panel h2 {
-        font-size: 12px;
-    }
+  .reference-panel p {
+    font-size: 11px;
+    margin: 0;
+    width: 100%;
+    text-align: justify;
+  }
 
-    .reference-panel p {
-        font-size: 11px;
-        margin: 0;
-        width: 100%;
-        text-align: justify;
-    }
-
-    .reference-panel div img {
-        margin: 0 0 10px 10px;
-        border-radius: 4px;
-        box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.35);
-        float: right;
-        max-width: 130px;
-        height: fit-content;
-    }
+  .reference-panel div img {
+    margin: 0 0 10px 10px;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.35);
+    float: right;
+    max-width: 130px;
+    height: fit-content;
+  }
 }

--- a/frontend/src/components/Lens/lensHelper.tsx
+++ b/frontend/src/components/Lens/lensHelper.tsx
@@ -1,47 +1,60 @@
-import {useState} from "react";
-import ReferencePanel from "./panels/reference";
-import DefinePanel from "./panels/definition";
+import { useState } from 'react';
+import ReferencePanel from './panels/reference';
+import DefinePanel from './panels/definition';
 
 export interface PanelProps {
-    selectionText: string;
+  selectionText: string;
 }
 
 export enum LensPanels {
-    REFERENCE= "reference",
-    DEFINE= "define",
-    TRANSLATE= "translate",
-    BOOKS= "books",
-    MEDIA= "media",
+  REFERENCE = 'reference',
+  DEFINE = 'define',
+  TRANSLATE = 'translate',
+  BOOKS = 'books',
+  MEDIA = 'media',
 }
 
-export default function LensHelper({ textSelection }: { textSelection: string }) {
-    const  [selectionPanel, setSelectionPanel] = useState<LensPanels>(LensPanels.REFERENCE);
-    const chosenPanel = () => {
-        switch (selectionPanel) {
-            case LensPanels.BOOKS:
-            case LensPanels.MEDIA:
-            case LensPanels.TRANSLATE:
-                return <><h2>IN PROGRESS</h2></>;
-            case LensPanels.REFERENCE:
-                return  <ReferencePanel selectionText={textSelection}/>
-            case LensPanels.DEFINE:
-                return  <DefinePanel selectionText={textSelection}/>
-        }
+export default function LensHelper({
+  textSelection,
+}: {
+  textSelection: string;
+}) {
+  const [selectionPanel, setSelectionPanel] = useState<LensPanels>(
+    LensPanels.REFERENCE
+  );
+  const chosenPanel = () => {
+    switch (selectionPanel) {
+      case LensPanels.BOOKS:
+      case LensPanels.MEDIA:
+      case LensPanels.TRANSLATE:
+        return (
+          <>
+            <h2>IN PROGRESS</h2>
+          </>
+        );
+      case LensPanels.REFERENCE:
+        return <ReferencePanel selectionText={textSelection} />;
+      case LensPanels.DEFINE:
+        return <DefinePanel selectionText={textSelection} />;
     }
+  };
 
-    return (
-        <div className={"lens-panel"}>
-            <div className={"lens-panel-content"}>
-            {chosenPanel()}
-            </div>
-            <div className={"choices"}>
-                {Object.entries(LensPanels).map((panel) => {
-                   return <button
-                       key={panel[0]}
-                       className={panel[1] === selectionPanel? "selected-panel": ""}
-                       onClick={() => setSelectionPanel(panel[1])}>{panel[1]}</button>
-                })}
-            </div>
-        </div>
-    );
+  return (
+    <div className={'lens-panel'}>
+      <div className={'lens-panel-content'}>{chosenPanel()}</div>
+      <div className={'choices'}>
+        {Object.entries(LensPanels).map((panel) => {
+          return (
+            <button
+              key={panel[0]}
+              className={panel[1] === selectionPanel ? 'selected-panel' : ''}
+              onClick={() => setSelectionPanel(panel[1])}
+            >
+              {panel[1]}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/Lens/panels/definition.tsx
+++ b/frontend/src/components/Lens/panels/definition.tsx
@@ -1,50 +1,55 @@
-import {PanelProps} from "../lensHelper";
-import {useEffect, useState} from "react";
+import { PanelProps } from '../lensHelper';
+import { useEffect, useState } from 'react';
 
 interface IDef {
-    definition: string;
-    example: string;
-    // synonyms: any;
-    // antonyms: any;
+  definition: string;
+  example: string;
+  // synonyms: any;
+  // antonyms: any;
 }
 
 interface IDefinition {
-    word: string;
-    origin: string;
-    // phonetics: any;
-    // phonetic: any;
-    meanings: { partofspeech: string; definitions: IDef[] }[];
+  word: string;
+  origin: string;
+  // phonetics: any;
+  // phonetic: any;
+  meanings: { partofspeech: string; definitions: IDef[] }[];
 }
 
 export default function DefinePanel(panelProps: PanelProps) {
-    const [definition, setSelectionDefinition] = useState<IDefinition | undefined>(undefined);
+  const [definition, setSelectionDefinition] = useState<
+    IDefinition | undefined
+  >(undefined);
 
-    useEffect(() => {
-        fetchDefiniton(panelProps.selectionText);
-    }, []);
+  useEffect(() => {
+    fetchDefiniton(panelProps.selectionText);
+  }, []);
 
-    async function fetchDefiniton(selectionText: string) {
-        const result = await fetch(
-            `https://api.dictionaryapi.dev/api/v2/entries/en/${selectionText}`,        {
-                method: 'GET',
-            }
-        );
-        const def: IDefinition[] = (await result.json()) as IDefinition[];
-        setSelectionDefinition(def[0]);
-    }
+  async function fetchDefiniton(selectionText: string) {
+    const result = await fetch(
+      `https://api.dictionaryapi.dev/api/v2/entries/en/${selectionText}`,
+      {
+        method: 'GET',
+      }
+    );
+    const def: IDefinition[] = (await result.json()) as IDefinition[];
+    setSelectionDefinition(def[0]);
+  }
 
-    return (<div className={"reference-panel"}>
-        <h2>{panelProps.selectionText}</h2>
-        <div>
-            {definition &&
-                definition.meanings &&
-                definition.meanings.map((m) => (
-                    <div key={m.partofspeech}>
-                        {m.definitions.map((word) => (
-                            <p key={word.definition}>{word.definition}</p>
-                        ))}
-                    </div>
-                ))}
-        </div>
-    </div>)
+  return (
+    <div className={'reference-panel'}>
+      <h2>{panelProps.selectionText}</h2>
+      <div>
+        {definition &&
+          definition.meanings &&
+          definition.meanings.map((m) => (
+            <div key={m.partofspeech}>
+              {m.definitions.map((word) => (
+                <p key={word.definition}>{word.definition}</p>
+              ))}
+            </div>
+          ))}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/Lens/panels/reference.tsx
+++ b/frontend/src/components/Lens/panels/reference.tsx
@@ -1,53 +1,64 @@
-import {PanelProps} from "../lensHelper";
-import {useEffect, useState} from "react";
-
+import { PanelProps } from '../lensHelper';
+import { useEffect, useState } from 'react';
 
 interface ReferenceInterface {
-    imageSource: string;
-    extract: string;
-    description: string;
+  imageSource: string;
+  extract: string;
+  description: string;
 }
 
 export default function ReferencePanel(panelProps: PanelProps) {
-    const {selectionText} = panelProps
-    const [referenceData, setReferenceData] = useState<ReferenceInterface | undefined>(undefined)
+  const { selectionText } = panelProps;
+  const [referenceData, setReferenceData] = useState<
+    ReferenceInterface | undefined
+  >(undefined);
 
-    async function fetchInformation() {
-        const result = await fetch(
-            `https://en.wikipedia.org/api/rest_v1/page/summary/${selectionText.replace(' ', '_')}`,
-            {
-                method: 'GET',
-            }
-        );
-        const response = await result.json();
-        try {
-            setReferenceData({
-                extract: response.extract, description: response.description, imageSource:
-                response.thumbnail.source
-            })
-        } catch (e) {
-            setReferenceData(undefined)
-        }
+  async function fetchInformation() {
+    const result = await fetch(
+      `https://en.wikipedia.org/api/rest_v1/page/summary/${selectionText.replace(
+        ' ',
+        '_'
+      )}`,
+      {
+        method: 'GET',
+      }
+    );
+    const response = await result.json();
+    try {
+      setReferenceData({
+        extract: response.extract,
+        description: response.description,
+        imageSource: response.thumbnail.source,
+      });
+    } catch (e) {
+      setReferenceData(undefined);
     }
+  }
 
-    useEffect(() => {
-        fetchInformation();
-    }, []);
+  useEffect(() => {
+    fetchInformation();
+  }, []);
 
+  if (!referenceData) {
+    return (
+      <div>
+        <h2>No Results</h2>
+      </div>
+    );
+  }
 
-    if (!referenceData) {
-        return <div>
-            <h2>No Results</h2>
-        </div>
-    }
-
-    return (<div className={"reference-panel"}>
-        <h2>{selectionText}</h2>
-        <div>
+  return (
+    <div className={'reference-panel'}>
+      <h2>{selectionText}</h2>
+      <div>
         <p>
-            <img src={referenceData.imageSource} alt={referenceData.description}/>
-            {referenceData.extract}
+          <img
+            src={referenceData.imageSource}
+            alt={referenceData.description}
+          />
+          {referenceData.extract}
         </p>
-        </div>
-    </div>)
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/Loader/loader.scss
+++ b/frontend/src/components/Loader/loader.scss
@@ -1,63 +1,71 @@
 #launchpad-essentially {
-    .loader {
-        background: none;
-    }
+  .loader {
+    background: none;
+  }
 
-    .progressbar {
-        width: 250;
-        max-width: inherit;
-        display: flex;
-        align-items: flex-start;
-        flex-direction: column;
-        justify-content: flex-start;
-        color: #191b43;
-        background-position: right;
-        animation: makeItfadeIn 4s ease-in 0s forwards;
-        background: linear-gradient(to right, var(--extension-secondary) 50%, var(--extension-primary) 50%);
-        border: 1px solid var(--extension-primary);
-        background-size: 200% 100%;
-        background-position: right bottom;
-        padding: 10px 20px;
-        margin-top: 5px;
-        border-radius: 10px;
-    }
+  .progressbar {
+    width: 250;
+    max-width: inherit;
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: flex-start;
+    color: #191b43;
+    background-position: right;
+    animation: makeItfadeIn 4s ease-in 0s forwards;
+    background: linear-gradient(
+      to right,
+      var(--extension-secondary) 50%,
+      var(--extension-primary) 50%
+    );
+    border: 1px solid var(--extension-primary);
+    background-size: 200% 100%;
+    background-position: right bottom;
+    padding: 10px 20px;
+    margin-top: 5px;
+    border-radius: 10px;
+  }
 
-    .progressbar.mainbar {
-        width: 250;
-        animation: none;
-    }
+  .progressbar.mainbar {
+    width: 250;
+    animation: none;
+  }
 
-    .progressbar h6 {
-        font-size: 16px;
-    }
+  .progressbar h6 {
+    font-size: 16px;
+  }
 
-    .progressbar h1 {
-        font-size: 18px;
-        color: var(--extension-secondary);
-    }
+  .progressbar h1 {
+    font-size: 18px;
+    color: var(--extension-secondary);
+  }
 
-    .progressbar p {
-        margin-top: 10px;
-        font-size: 9px;
-        width: 250px;
-    }
+  .progressbar p {
+    margin-top: 10px;
+    font-size: 9px;
+    width: 250px;
+  }
 
-    .progressbars {
-        border: 0.7px dashed var(--extension-secondary);
-        padding: 10px;
-        box-shadow: 0px 2px 7px 1px rgba(0, 0, 0, 0.15);
-        animation: makeItfadeIn 1s ease-in 40s forwards;
-        background: linear-gradient(to right, var(--extension-secondary) 50%, var(--extension-primary) 50%);
-        border: 1px solid var(--extension-primary);
-        background-size: 200% 100%;
-        background-position: right bottom;
-        border-radius: 10px;
-    }
+  .progressbars {
+    border: 0.7px dashed var(--extension-secondary);
+    padding: 10px;
+    box-shadow: 0px 2px 7px 1px rgba(0, 0, 0, 0.15);
+    animation: makeItfadeIn 1s ease-in 40s forwards;
+    background: linear-gradient(
+      to right,
+      var(--extension-secondary) 50%,
+      var(--extension-primary) 50%
+    );
+    border: 1px solid var(--extension-primary);
+    background-size: 200% 100%;
+    background-position: right bottom;
+    border-radius: 10px;
+  }
 
-    @keyframes makeItfadeIn {
-        100% {
-            background-position: left bottom;
-            color: #ffffff;
-        }
+  @keyframes makeItfadeIn {
+    100% {
+      background-position: left bottom;
+      color: #ffffff;
     }
+  }
 }

--- a/frontend/src/components/Sidebar/sidebar.scss
+++ b/frontend/src/components/Sidebar/sidebar.scss
@@ -1,11 +1,11 @@
 #launchpad-essentially {
-    .sidebar {
-        width: 50px;
-        background-color: var(--extension-secondary);
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        align-items: center;
-        padding: 20px 5px;
-    }
+  .sidebar {
+    width: 50px;
+    background-color: var(--extension-secondary);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 5px;
+  }
 }


### PR DESCRIPTION
1. Reformat front-end code with command `npm run format` ([commit](https://github.com/ubclaunchpad/Essentially/commit/e6eb941ddc4b2306d02c29eee0b9c74d06b4f018))
2. Assign default value for `date` and `author` if not retrieved:
    - `date`: current date
    - `author`: display site name if can't get arthur name, display "@news" if can't get `author` and `site`
and display retrieved article meta data ([commit](https://github.com/ubclaunchpad/Essentially/commit/f73d71cceb09926de81f711ef7ac0272d9fc3160))

resolves #51 

result:
<img width="489" alt="Snipaste_2022-12-15_12-58-15" src="https://user-images.githubusercontent.com/41638995/207966704-549a9411-5459-473b-8b73-4e6eaa826434.png">

<img width="489" alt="Snipaste_2022-12-15_12-45-50" src="https://user-images.githubusercontent.com/41638995/207966842-d1a0e86d-6eaf-47c3-ab9f-5af0b30649c5.png">

<img width="489" alt="Snipaste_2022-12-15_12-58-36" src="https://user-images.githubusercontent.com/41638995/207966868-794a1666-cc92-4ee9-b336-ad08d14fc734.png">


